### PR TITLE
Expose lock screen blurring as a setting [2/2]

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarWindowManager.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarWindowManager.java
@@ -19,8 +19,10 @@ package com.android.systemui.statusbar.phone;
 import android.content.Context;
 import android.content.pm.ActivityInfo;
 import android.content.res.Resources;
+import android.database.ContentObserver;
 import android.graphics.Point;
 import android.graphics.PixelFormat;
+import android.os.Handler;
 import android.os.SystemProperties;
 import android.util.Log;
 import android.view.Gravity;
@@ -36,7 +38,6 @@ import com.android.systemui.statusbar.BaseStatusBar;
 import com.android.systemui.statusbar.StatusBarState;
 import com.android.systemui.statusbar.policy.KeyguardMonitor;
 import cyanogenmod.providers.CMSettings;
-import org.cyanogenmod.internal.util.CmLockPatternUtils;
 
 import java.io.FileDescriptor;
 import java.io.PrintWriter;
@@ -79,8 +80,6 @@ public class StatusBarWindowManager implements KeyguardMonitor.Callback {
 
         mKeyguardMonitor = kgm;
         mKeyguardMonitor.addCallback(this);
-        mKeyguardBlurEnabled = mContext.getResources().getBoolean(
-                com.android.internal.R.bool.config_ui_blur_enabled);
         mFxSession = new SurfaceSession();
     }
 
@@ -121,7 +120,11 @@ public class StatusBarWindowManager implements KeyguardMonitor.Callback {
         mLpChanged = new WindowManager.LayoutParams();
         mLpChanged.copyFrom(mLp);
 
-        if (mKeyguardBlurEnabled) {
+        boolean blurSupported = mContext.getResources().getBoolean(
+                com.android.internal.R.bool.config_ui_blur_enabled);
+        mKeyguardBlurEnabled = CMSettings.Secure.getInt(mContext.getContentResolver(),
+                CMSettings.Secure.LOCK_SCREEN_BLUR_ENABLED, blurSupported ? 1 : 0) == 1;
+        if (blurSupported) {
             Display display = mWindowManager.getDefaultDisplay();
             Point xy = new Point();
             display.getRealSize(xy);
@@ -129,6 +132,9 @@ public class StatusBarWindowManager implements KeyguardMonitor.Callback {
             if (mKeyguardBlur != null) {
                 mKeyguardBlur.setLayer(STATUS_BAR_LAYER - 2);
             }
+
+            SettingsObserver observer = new SettingsObserver(new Handler());
+            observer.observe(mContext);
         }
     }
 
@@ -260,8 +266,7 @@ public class StatusBarWindowManager implements KeyguardMonitor.Callback {
         boolean isblur = false;
         if (mCurrentState.keyguardShowing && mKeyguardBlurEnabled
                 && !mCurrentState.keyguardOccluded
-                && !mShowingMedia
-                && !isShowingLiveLockScreen()) {
+                && !mShowingMedia) {
             isblur = true;
         }
         if (mKeyguardBlur != null) {
@@ -397,13 +402,6 @@ public class StatusBarWindowManager implements KeyguardMonitor.Callback {
         return mCurrentState.keyguardExternalViewHasFocus;
     }
 
-    private boolean isShowingLiveLockScreen() {
-        CmLockPatternUtils lockPatternUtils = new CmLockPatternUtils(mContext);
-        return (CMSettings.Secure.getInt(mContext.getContentResolver(),
-                CMSettings.Secure.LIVE_LOCK_SCREEN_ENABLED, 0) == 1)
-                && lockPatternUtils.isThirdPartyKeyguardEnabled();
-    }
-
     private static class State {
         boolean keyguardShowing;
         boolean keyguardOccluded;
@@ -453,6 +451,32 @@ public class StatusBarWindowManager implements KeyguardMonitor.Callback {
             result.append("}");
 
             return result.toString();
+        }
+    }
+
+    private class SettingsObserver extends ContentObserver {
+        public SettingsObserver(Handler handler) {
+            super(handler);
+        }
+
+        public void observe(Context context) {
+            context.getContentResolver().registerContentObserver(
+                    CMSettings.Secure.getUriFor(CMSettings.Secure.LOCK_SCREEN_BLUR_ENABLED),
+                    false,
+                    this);
+        }
+
+        public void unobserve(Context context) {
+            context.getContentResolver().unregisterContentObserver(this);
+        }
+
+        @Override
+        public void onChange(boolean selfChange) {
+            // default to being enabled since we are here because the blur config was set to true
+            mKeyguardBlurEnabled = CMSettings.Secure.getInt(mContext.getContentResolver(),
+                    CMSettings.Secure.LOCK_SCREEN_BLUR_ENABLED, 1) == 1;
+            // update the state
+            apply(mCurrentState);
         }
     }
 }

--- a/services/core/java/com/android/server/wm/WindowAnimator.java
+++ b/services/core/java/com/android/server/wm/WindowAnimator.java
@@ -30,6 +30,8 @@ import static com.android.server.wm.WindowManagerService.LayoutFields.SET_ORIENT
 import static com.android.server.wm.WindowManagerService.LayoutFields.SET_WALLPAPER_ACTION_PENDING;
 
 import android.content.Context;
+import android.database.ContentObserver;
+import android.os.Handler;
 import android.os.RemoteException;
 import android.util.Slog;
 import android.util.SparseArray;
@@ -43,6 +45,8 @@ import android.view.animation.Animation;
 import android.view.Choreographer;
 
 import com.android.server.wm.WindowManagerService.LayoutFields;
+
+import cyanogenmod.providers.CMSettings;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -98,7 +102,7 @@ public class WindowAnimator {
     /** Use one animation for all entering activities after keyguard is dismissed. */
     Animation mPostKeyguardExitAnimation;
 
-    private final boolean mBlurUiEnabled;
+    private boolean mKeyguardBlurEnabled;
 
     // forceHiding states.
     static final int KEYGUARD_NOT_SHOWN     = 0;
@@ -120,8 +124,13 @@ public class WindowAnimator {
         mContext = service.mContext;
         mPolicy = service.mPolicy;
 
-        mBlurUiEnabled = mContext.getResources().getBoolean(
+        boolean blurUiEnabled = mContext.getResources().getBoolean(
                 com.android.internal.R.bool.config_ui_blur_enabled);
+
+        if (blurUiEnabled) {
+            SettingsObserver observer = new SettingsObserver(new Handler());
+            observer.observe(mContext);
+        }
 
         mAnimationFrameCallback = new Choreographer.FrameCallback() {
             public void doFrame(long frameTimeNs) {
@@ -223,7 +232,7 @@ public class WindowAnimator {
 
         // Only hide windows if the keyguard is active and not animating away.
         boolean keyguardOn = mPolicy.isKeyguardShowingOrOccluded()
-                && (mForceHiding != KEYGUARD_ANIMATING_OUT && !mBlurUiEnabled);
+                && (mForceHiding != KEYGUARD_ANIMATING_OUT && !mKeyguardBlurEnabled);
         return keyguardOn && !allowWhenLocked && (win.getDisplayId() == Display.DEFAULT_DISPLAY);
     }
 
@@ -232,7 +241,7 @@ public class WindowAnimator {
 
         final WindowList windows = mService.getWindowListLocked(displayId);
 
-        if (mKeyguardGoingAway && !mBlurUiEnabled) {
+        if (mKeyguardGoingAway && !mKeyguardBlurEnabled) {
             for (int i = windows.size() - 1; i >= 0; i--) {
                 WindowState win = windows.get(i);
                 if (!mPolicy.isKeyguardHostWindow(win.mAttrs)) {
@@ -247,7 +256,7 @@ public class WindowAnimator {
                         // Create a new animation to delay until keyguard is gone on its own.
                         winAnimator.mAnimation = new AlphaAnimation(1.0f, 1.0f);
                         winAnimator.mAnimation.setDuration(
-                                mBlurUiEnabled ? 0 : KEYGUARD_ANIM_TIMEOUT_MS);
+                                mKeyguardBlurEnabled ? 0 : KEYGUARD_ANIM_TIMEOUT_MS);
                         winAnimator.mAnimationIsEntrance = false;
                         winAnimator.mAnimationStartTime = -1;
                         winAnimator.mKeyguardGoingAwayAnimation = true;
@@ -337,7 +346,7 @@ public class WindowAnimator {
                         if (nowAnimating && win.mWinAnimator.mKeyguardGoingAwayAnimation) {
                             mForceHiding = KEYGUARD_ANIMATING_OUT;
                         } else {
-                            mForceHiding = win.isDrawnLw()  && !mBlurUiEnabled ?
+                            mForceHiding = win.isDrawnLw()  && !mKeyguardBlurEnabled ?
                                 KEYGUARD_SHOWN : KEYGUARD_NOT_SHOWN;
                         }
                     }
@@ -889,5 +898,31 @@ public class WindowAnimator {
 
     private class DisplayContentsAnimator {
         ScreenRotationAnimation mScreenRotationAnimation = null;
+    }
+
+    private class SettingsObserver extends ContentObserver {
+        public SettingsObserver(Handler handler) {
+            super(handler);
+        }
+
+        public void observe(Context context) {
+            context.getContentResolver().registerContentObserver(
+                    CMSettings.Secure.getUriFor(CMSettings.Secure.LOCK_SCREEN_BLUR_ENABLED),
+                    false,
+                    this);
+
+            onChange(true);
+        }
+
+        public void unobserve(Context context) {
+            context.getContentResolver().unregisterContentObserver(this);
+        }
+
+        @Override
+        public void onChange(boolean selfChange) {
+            // default to being enabled since we are here because the blur config was set to true
+            mKeyguardBlurEnabled = CMSettings.Secure.getInt(mContext.getContentResolver(),
+                    CMSettings.Secure.LOCK_SCREEN_BLUR_ENABLED, 1) == 1;
+        }
     }
 }


### PR DESCRIPTION
This will provide control over blurring since the current implementation
assumes it is always on provided the device config specifies it
supports blur.

Change-Id: If6d1f1290473df20bda7e96e42571285bd2d8967
TICKET: CYNGNOS-2610
