### PR TITLE
SystemUI: Restrict persistent USB drive notifications to USB disks

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/usb/StorageNotification.java
+++ b/packages/SystemUI/src/com/android/systemui/usb/StorageNotification.java
@@ -362,10 +362,13 @@ public class StorageNotification extends SystemUI {
                             mContext.getString(R.string.ext_media_unmount_action),
                             buildUnmountPendingIntent(vol)))
                     .setContentIntent(browseIntent)
-                    .setOngoing(mContext.getResources().getBoolean(
-                            R.bool.config_persistUsbDriveNotification))
                     .setCategory(Notification.CATEGORY_SYSTEM)
                     .setPriority(Notification.PRIORITY_LOW);
+            // USB disks notification can be persistent
+            if (disk.isUsb()) {
+                builder.setOngoing(mContext.getResources().getBoolean(
+                        R.bool.config_persistUsbDriveNotification));
+            }
             // Non-adoptable disks can't be snoozed.
             if (disk.isAdoptable()) {
                 builder.setDeleteIntent(buildSnoozeIntent(vol.getFsUuid()));


### PR DESCRIPTION
- Without the addition of the isUsb check, a regular FAT32 MicroSD
  would have a persistent notification that is unwished

Change-Id: I396a861702674d0a6a70beb5206fb4c7374ec85d
