### PR TITLE
SettingsProvider: fix data_enabled default lookup

### DIFF
--- a/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
@@ -2880,16 +2880,6 @@ class DatabaseHelper extends SQLiteOpenHelper {
                     R.bool.def_enable_mobile_data);
 
             int phoneCount = TelephonyManager.getDefault().getPhoneCount();
-            // SUB specific flags for Multisim devices
-            for (int phoneId = 0; phoneId < MAX_PHONE_COUNT; phoneId++) {
-                // Mobile Data default, based on build
-                loadRegionLockedBooleanSetting(stmt, Settings.Global.MOBILE_DATA + phoneId,
-                        R.bool.def_enable_mobile_data);
-
-                // Data roaming default, based on build
-                loadRegionLockedBooleanSetting(stmt, Settings.Global.DATA_ROAMING + phoneId,
-                        R.bool.def_enable_data_roaming);
-            }
 
             loadBooleanSetting(stmt, Settings.Global.NETSTATS_ENABLED,
                     R.bool.def_netstats_enabled);


### PR DESCRIPTION
We shouldn't set the MOBILE_DATA + phoneId keys because it will cause
collisions with other parts of the system that actually query
MOBILE_DATA + subId - leading to incorrect defaults.

TelephonyManager.getIntWithSubId() actually falls back to just
MOBILE_DATA for a specific sub id query, so we do not need to touch
these values, since it applies the same default to all sub ids anyways.

Ticket: CYNGNOS-3171

Change-Id: I38405000b3d641029080fb630eae4d128bd44719
Signed-off-by: Roman Birg roman@cyngn.com
