### PR TITLE
am: Account for time changes when showing recent activities

### DIFF
--- a/services/core/java/com/android/server/am/ActivityStack.java
+++ b/services/core/java/com/android/server/am/ActivityStack.java
@@ -4230,7 +4230,8 @@ final class ActivityStack {
             if (focusedStack && topTask) {
                 // Give the latest time to ensure foreground task can be sorted
                 // at the first, because lastActiveTime of creating task is 0.
-                ci.lastActiveTime = System.currentTimeMillis();
+                // Only do this if the clock didn't run backwards, though.
+                ci.lastActiveTime = Math.max(ci.lastActiveTime, System.currentTimeMillis());
                 topTask = false;
             }
 


### PR DESCRIPTION
[Procedures]
1. Go to Settings->Date&Time
   Set time backwards, eg. 2016.6.15 -> 2016.6.10
1. Tap recent apps button to show recent activities.
   There will be no activities shown.

Change-Id: Ifd860c0d08fac49f9d3c8eac590b6db9e6afb09d
