### PR TITLE
Prevent invocation of startNavigating() when GPS is off

### DIFF
--- a/services/core/java/com/android/server/location/GpsLocationProvider.java
+++ b/services/core/java/com/android/server/location/GpsLocationProvider.java
@@ -1118,7 +1118,7 @@ public class GpsLocationProvider implements LocationProviderInterface {
         }
 
         if (DEBUG) Log.d(TAG, "setRequest " + mProviderRequest);
-        if (mProviderRequest.reportLocation && !mDisableGps) {
+        if (mProviderRequest.reportLocation && !mDisableGps && isEnabled()) {
             // update client uids
             updateClientUids(mWorkSource);
 


### PR DESCRIPTION
When system comes back from idle state, GpsLocationProvider
invokes startNavigating() even when GPS is turned off in
settings.

Change-Id: Ie6dbf60a743cce429ab83876a3cb80f7e4b0e0f6
CRs-Fixed: 1022372
