### PR TITLE
SysUI: Don't set panel bar to null and avoid NPEs

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PanelBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PanelBar.java
@@ -146,16 +146,6 @@ public abstract class PanelBar extends FrameLayout {
         return result;
     }
 
-    @Override
-    protected void onDetachedFromWindow() {
-        super.onDetachedFromWindow();
-        for (PanelView pv : mPanels) {
-            pv.setBar(null);
-        }
-        mPanels.clear();
-        mPanelHolder.setBar(null);
-    }
-
     // called from PanelView when self-expanding, too
     public void startOpeningPanel(PanelView panel) {
         if (DEBUG) LOG("startOpeningPanel: " + panel);


### PR DESCRIPTION
This patch removes the onDetachedFromWindow method introduced in
change Ieaec759e4378a9a7701e6fba46ed33464caaee0a.  It is not
necessary to set the panel bar to null in the PanelViews or the
PanelHolder in order for these objects to be GC'ed when recreating
the status bar after a theme change or a user switch.

Change-Id: I67f1e8289d04df2f5daefdb206030d7f0404d714
TICKET: HAM-1551
